### PR TITLE
Signhost::__construct() type hints

### DIFF
--- a/src/Signhost.php
+++ b/src/Signhost.php
@@ -24,13 +24,13 @@ class Signhost
     /**
      * Signhost constructor.
      *
-     * @param $appName
-     * @param $appKey
-     * @param $apiKey
+     * @param string $appName
+     * @param string $appKey
+     * @param string $apiKey
      * @param null $sharedSecret
      * @param string $environment
      */
-    public function __construct($appName, $appKey, $apiKey, $sharedSecret = null, $environment = 'production')
+    public function __construct(string $appName, string $appKey, string $apiKey, $sharedSecret = null, string $environment = 'production')
     {
         $this->client = new SignhostClient($appName, $appKey, $apiKey, $sharedSecret, $environment);
         // must we return array of objects?

--- a/src/Signhost.php
+++ b/src/Signhost.php
@@ -27,10 +27,10 @@ class Signhost
      * @param string $appName
      * @param string $appKey
      * @param string $apiKey
-     * @param null $sharedSecret
+     * @param string $sharedSecret
      * @param string $environment
      */
-    public function __construct(string $appName, string $appKey, string $apiKey, $sharedSecret = null, string $environment = 'production')
+    public function __construct(string $appName, string $appKey, string $apiKey, string $sharedSecret = null, string $environment = 'production')
     {
         $this->client = new SignhostClient($appName, $appKey, $apiKey, $sharedSecret, $environment);
         // must we return array of objects?


### PR DESCRIPTION
Add string type hints so constructing with missing configs (null values) directly causes Exceptions.