### PR TITLE
Cleaning up some code

### DIFF
--- a/src/Signhost.php
+++ b/src/Signhost.php
@@ -49,7 +49,7 @@ class Signhost
      */
     public function createTransaction($transaction)
     {
-        $response = $this->client->execute("/transaction", "POST", $transaction);
+        $response = $this->client->performRequest("/transaction", "POST", $transaction);
 
         return json_decode($response,$this->shouldReturnArray);
     }
@@ -63,7 +63,7 @@ class Signhost
      */
     public function getTransaction($transactionId)
     {
-        $response = $this->client->execute("/transaction/" . $transactionId, "GET");
+        $response = $this->client->performRequest("/transaction/" . $transactionId, "GET");
 
         return json_decode($response,$this->shouldReturnArray);
     }
@@ -77,7 +77,7 @@ class Signhost
      */
     public function deleteTransaction($transactionId)
     {
-        $response = $this->client->execute("/transaction/" . $transactionId, "DELETE");
+        $response = $this->client->performRequest("/transaction/" . $transactionId, "DELETE");
 
         return json_decode($response,$this->shouldReturnArray);
     }
@@ -91,7 +91,7 @@ class Signhost
      */
     public function startTransaction($transactionId)
     {
-        $response = $this->client->execute("/transaction/" . $transactionId . "/start", "PUT");
+        $response = $this->client->performRequest("/transaction/" . $transactionId . "/start", "PUT");
 
         return json_decode($response,$this->shouldReturnArray);
     }
@@ -108,7 +108,7 @@ class Signhost
     public function addOrReplaceFile($transactionId, $fileId, $filePath)
     {
         // execute command to signhost server
-        $response = $this->client->execute("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "PUT", null, $filePath);
+        $response = $this->client->performRequest("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "PUT", null, $filePath);
 
         return json_decode($response,$this->shouldReturnArray);
     }
@@ -124,7 +124,7 @@ class Signhost
      */
     public function addOrReplaceMetadata($transactionId, $fileId, $metadata)
     {
-        $response = $this->client->execute("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "PUT", $metadata);
+        $response = $this->client->performRequest("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "PUT", $metadata);
 
         return json_decode($response,$this->shouldReturnArray);
     }
@@ -138,7 +138,7 @@ class Signhost
      */
     public function getReceipt($transactionId)
     {
-        $response = $this->client->execute("/file/receipt/" . $transactionId, "GET");
+        $response = $this->client->performRequest("/file/receipt/" . $transactionId, "GET");
 
         return $response;
     }
@@ -153,7 +153,7 @@ class Signhost
      */
     public function getDocument($transactionId, $fileId)
     {
-        $response = $this->client->execute("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "GET");
+        $response = $this->client->performRequest("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "GET");
 
         return $response;
     }
@@ -186,7 +186,7 @@ class Signhost
      */
     public function setIgnoreStatusCode($ignoreStatusCode)
     {
-        $this->client->setIgnoreStatusCode($ignoreStatusCode);
+        $this->client->setShouldIgnoreHttpErrors($ignoreStatusCode);
         return $this;
     }
 

--- a/src/Signhost.php
+++ b/src/Signhost.php
@@ -61,7 +61,7 @@ class Signhost
      * @return mixed
      * @throws SignHostException
      */
-    public function GetTransaction($transactionId)
+    public function getTransaction($transactionId)
     {
         $response = $this->client->execute("/transaction/" . $transactionId, "GET");
 
@@ -75,7 +75,7 @@ class Signhost
      * @return mixed
      * @throws SignHostException
      */
-    public function DeleteTransaction($transactionId)
+    public function deleteTransaction($transactionId)
     {
         $response = $this->client->execute("/transaction/" . $transactionId, "DELETE");
 
@@ -89,7 +89,7 @@ class Signhost
      * @return mixed
      * @throws SignHostException
      */
-    public function StartTransaction($transactionId)
+    public function startTransaction($transactionId)
     {
         $response = $this->client->execute("/transaction/" . $transactionId . "/start", "PUT");
 
@@ -105,7 +105,7 @@ class Signhost
      * @return mixed
      * @throws SignHostException
      */
-    public function AddOrReplaceFile($transactionId, $fileId, $filePath)
+    public function addOrReplaceFile($transactionId, $fileId, $filePath)
     {
         // execute command to signhost server
         $response = $this->client->execute("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "PUT", null, $filePath);
@@ -122,7 +122,7 @@ class Signhost
      * @return mixed
      * @throws SignHostException
      */
-    public function AddOrReplaceMetadata($transactionId, $fileId, $metadata)
+    public function addOrReplaceMetadata($transactionId, $fileId, $metadata)
     {
         $response = $this->client->execute("/transaction/" . $transactionId . "/file/" . rawurlencode($fileId), "PUT", $metadata);
 

--- a/src/SignhostClient.php
+++ b/src/SignhostClient.php
@@ -240,23 +240,19 @@ class SignhostClient
             return;
         }
 
+        $message = 'Unknown error';
         if ($statusCode >= 400 && $statusCode <= 499) {
             // decode message from json string
             $object = json_decode($response, false);
             $message = $object->Message ?? 'Unknown error';
-
-            throw new SignhostException(
-                "Response: $statusCode - $message",
-                $statusCode
-            );
+        } elseif ($statusCode > 500 && $statusCode <= 599) {
+            $message = 'Internal server error on remote server';
         }
 
-        if ($statusCode > 500 && $statusCode <= 599) {
-            throw new SignhostException(
-                "Response: $statusCode - Internal Server Error on Signhost.com server.",
-                $statusCode
-            );
-        }
+        throw new SignhostException(
+            "Response code: $statusCode, message: $message",
+            $statusCode
+        );
     }
 
     /**

--- a/src/SignhostClient.php
+++ b/src/SignhostClient.php
@@ -135,7 +135,7 @@ class SignhostClient
             // bind file handler and curl handler
             curl_setopt($ch, CURLOPT_INFILE, $fh);
             // calculate file Checksum
-            $fileChecksum = $this->calculateFileChecsum($filePath);
+            $fileChecksum = $this->calculateFileChecksum($filePath);
             // replace Content-Type header with application/pdf
             $headers = array_replace($headers, [0 => "Content-Type: application/pdf"]);
             // merge filechecksum with other headers
@@ -267,7 +267,7 @@ class SignhostClient
      * @param $filePath
      * @return string
      */
-    private function calculateFileChecsum($filePath)
+    private function calculateFileChecksum($filePath)
     {
         return base64_encode(pack('H*', hash_file('sha256', $filePath)));
     }


### PR DESCRIPTION
In this change I've tried to clean up some code duplication, some typo's and moved some things around so that they're less scattered. For instance:

- Error checking during JSON parsing in the SignHost class is now stricter and therefor done in one place. 
- all curl related code now centralized in one method
- look at statuscodes like ints instead of strings
