### PR TITLE
Adding Content-Length: 0 Head on PUT start transaction call

### DIFF
--- a/src/SignhostClient.php
+++ b/src/SignhostClient.php
@@ -90,7 +90,12 @@ class SignhostClient
             if ("GET" === $method || "HEAD" === $method && !isset($filePath)) {
                 unset($headers[0]); // unset Content-Type
             }
-            
+
+            // for start transaction, SignHost will require the content-lenth: 0 header.
+            if (false !== strpos($endpoint, 'start')) {
+                $headers[] = "Content-Length: 0";
+            }
+
             // Initialize a cURL session
             return $this->performCURLRequest(
                 $method,


### PR DESCRIPTION
For some reason SignHost.com requires the Content-Lenght header on the startTransaction call. this PR adds it. (might be nice to add this as header on the specific call though, instead of str_pos() the URL for 'start'.... but it works)