### PR TITLE
Fix digest header format

### DIFF
--- a/src/SignhostClient.php
+++ b/src/SignhostClient.php
@@ -81,7 +81,7 @@ class SignhostClient
                 $uploadFileHandle = fopen($filePath, 'rb');
 
                 $headers[] = 'Content-Type: application/pdf';
-                $headers[]  = 'Digest: SHA256=' . base64_encode(pack('H*', hash_file('sha256', $filePath)));
+                $headers[]  = 'Digest: SHA-256=' . base64_encode(pack('H*', hash_file('sha256', $filePath)));
             }
 
             // When data is set, we must add Content-Type: application/json header


### PR DESCRIPTION
Evidos has announced that an update will go live sometime during the week of March 10, 2025. After this update, sign requests with an invalid Digest header format will be rejected. This change ensures compatibility with their updated requirements.

This update corrects the Digest header format to ensure compliance with RFC-5843 and aligns with the example provided in the 
[https://evidos.github.io/endpoints/##/paths//api/transaction/%7BtransactionId%7D/file/%7BfileId%7D/put](url)

I tested the new code to ensure it works, and it functions as expected.

